### PR TITLE
Rename quiteZone to quietZone

### DIFF
--- a/QRSmith/src/main/java/com/akansh/qrsmith/HexagonalQR.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/HexagonalQR.java
@@ -53,8 +53,8 @@ class HexagonalQR {
         // Calculate dimensions
         int inputWidth = input.getWidth();
         int inputHeight = input.getHeight();
-        int qrWidth = inputWidth + (qrOptions.quiteZone * 2);
-        int qrHeight = inputHeight + (qrOptions.quiteZone * 2);
+        int qrWidth = inputWidth + (qrOptions.quietZone * 2);
+        int qrHeight = inputHeight + (qrOptions.quietZone * 2);
         int outputWidth = Math.max(qrOptions.width, qrWidth);
         int outputHeight = Math.max(qrOptions.height, qrHeight);
 

--- a/QRSmith/src/main/java/com/akansh/qrsmith/NormalQR.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/NormalQR.java
@@ -17,7 +17,7 @@ import java.util.Map;
 class NormalQR {
     public static Bitmap renderQRImage(String content, QRCodeOptions qrOptions, ErrorCorrectionLevel errorCorrectionLevel) throws WriterException {
         Map<EncodeHintType, Object> hints = new HashMap<>();
-        hints.put(EncodeHintType.MARGIN, qrOptions.quiteZone);
+        hints.put(EncodeHintType.MARGIN, qrOptions.quietZone);
         hints.put(EncodeHintType.ERROR_CORRECTION, errorCorrectionLevel);
 
         BitMatrix bitMatrix = new MultiFormatWriter().encode(

--- a/QRSmith/src/main/java/com/akansh/qrsmith/QRCodeOptions.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/QRCodeOptions.java
@@ -6,7 +6,7 @@ import android.graphics.Color;
 public class QRCodeOptions {
     public int width = 500;
     public int height = 500;
-    public int quiteZone = 1;
+    public int quietZone = 1;
     public Bitmap logo = null;
     public Bitmap background = null;
     public int backgroundColor = Color.WHITE;

--- a/QRSmith/src/main/java/com/akansh/qrsmith/RoundQR.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/RoundQR.java
@@ -53,8 +53,8 @@ class RoundQR {
         // Calculate dimensions
         int inputWidth = input.getWidth();
         int inputHeight = input.getHeight();
-        int qrWidth = inputWidth + (qrOptions.quiteZone * 2);
-        int qrHeight = inputHeight + (qrOptions.quiteZone * 2);
+        int qrWidth = inputWidth + (qrOptions.quietZone * 2);
+        int qrHeight = inputHeight + (qrOptions.quietZone * 2);
         int outputWidth = Math.max(qrOptions.width, qrWidth);
         int outputHeight = Math.max(qrOptions.height, qrHeight);
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ options.height = 500;
 options.foregroundColor = Color.BLACK;
 options.backgroundColor = Color.WHITE;
 options.style = QRSmith.QRCodeStyle.SQUARED;
-options.quiteZone = 1; // Set quiet zone size
+options.quietZone = 1; // Set quiet zone size
 
 try {
     // Generate the QR code
@@ -106,7 +106,7 @@ options.logo = logo;
 options.background = background; // Set custom background
 options.dotSizeFactor = 0.8f;
 options.errorCorrectionLevel = QRSmith.QRErrorCorrectionLevel.Q;
-options.quiteZone = 2; // Set quiet zone size
+options.quietZone = 2; // Set quiet zone size
 
 try {
     // Generate the QR code
@@ -134,7 +134,7 @@ QRSmith offers extensive customization through the `QRCodeOptions` class:
 | `clearLogoBackground`  | Clears the background under the logo              | `true`        |
 | `background`           | Bitmap for the QR code background                 | `null`        |
 | `logoPadding`          | Padding around the logo                           | `0`           |
-| `quiteZone`            | Quiet zone size around the QR code                | `1`           |
+| `quietZone`            | Quiet zone size around the QR code                | `1`           |
 
 ## Supported QR Code Styles
 

--- a/app/src/main/java/com/akansh/qrsmith/MainActivity.java
+++ b/app/src/main/java/com/akansh/qrsmith/MainActivity.java
@@ -41,7 +41,7 @@ public class MainActivity extends AppCompatActivity {
 //        options.logo = logo;
 //        options.background = bg;
         options.clearLogoBackground = true;
-        options.quiteZone = 1;
+        options.quietZone = 1;
         options.dotSizeFactor = 1f;
 
         Bitmap bitmap = QRSmith.generateQRCode("Hello, World!", options);


### PR DESCRIPTION
## Summary
- fix typo `quiteZone` -> `quietZone` in QR code options
- update usages in generator classes and sample activity
- document `quietZone` option in README examples and table

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6852f4fdb7a88332b70869074a9587af