### PR TITLE
Encapsulate QR code options with builder

### DIFF
--- a/QRSmith/src/main/java/com/akansh/qrsmith/QRSmith.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/QRSmith.java
@@ -21,11 +21,15 @@ public class QRSmith {
         ErrorCorrectionLevel errorCorrectionLevel = getErrorCorrectionLevel(options);
 
         try {
-            if (options.logoPadding != 0) {
-                options.logo = addPaddingToBitmap(options.logo, options.logoPadding);
+            Bitmap logo = options.getLogo();
+            if (options.getLogoPadding() != 0) {
+                logo = addPaddingToBitmap(logo, options.getLogoPadding());
             }
+            QRCodeOptions paddedOptions = new QRCodeOptions.Builder(options)
+                    .setLogo(logo)
+                    .build();
             QRRenderer qrRenderer = new QRRenderer();
-            qrBitmap = qrRenderer.renderQRImage(content, options, errorCorrectionLevel);
+            qrBitmap = qrRenderer.renderQRImage(content, paddedOptions, errorCorrectionLevel);
         } catch (Exception e) {
             Log.e("QRSmith", "Error generating QR code", e);
         }
@@ -34,7 +38,7 @@ public class QRSmith {
 
     private static ErrorCorrectionLevel getErrorCorrectionLevel(QRCodeOptions options) {
         ErrorCorrectionLevel errorCorrectionLevel;
-        switch (options.errorCorrectionLevel) {
+        switch (options.getErrorCorrectionLevel()) {
             case L:
                 errorCorrectionLevel = ErrorCorrectionLevel.L;
                 break;

--- a/QRSmith/src/main/java/com/akansh/qrsmith/model/QRCodeOptions.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/model/QRCodeOptions.java
@@ -4,19 +4,96 @@ import android.graphics.Bitmap;
 import android.graphics.Color;
 
 public class QRCodeOptions {
+    private final int width;
+    private final int height;
+    private final int quietZone;
+    private final Bitmap logo;
+    private final Bitmap background;
+    private final int backgroundColor;
+    private final int foregroundColor;
+    private final QRErrorCorrectionLevel errorCorrectionLevel;
+    private final float dotSizeFactor;
+    private final boolean clearLogoBackground;
+    private final int logoPadding;
+    private final QRStyles.EyeShape eyeShape;
+    private final QRStyles.PatternStyle patternStyle;
 
-    public int width = 500;
-    public int height = 500;
-    public int quietZone = 1;
-    public Bitmap logo = null;
-    public Bitmap background = null;
-    public int backgroundColor = Color.WHITE;
-    public int foregroundColor = Color.BLACK;
-    public QRErrorCorrectionLevel errorCorrectionLevel = QRErrorCorrectionLevel.H; // Default error correction level
-    public float dotSizeFactor = 0.8f;
-    public boolean clearLogoBackground = true;
-    public int logoPadding = 0;
+    private QRCodeOptions(Builder builder) {
+        this.width = builder.width;
+        this.height = builder.height;
+        this.quietZone = builder.quietZone;
+        this.logo = builder.logo;
+        this.background = builder.background;
+        this.backgroundColor = builder.backgroundColor;
+        this.foregroundColor = builder.foregroundColor;
+        this.errorCorrectionLevel = builder.errorCorrectionLevel;
+        this.dotSizeFactor = builder.dotSizeFactor;
+        this.clearLogoBackground = builder.clearLogoBackground;
+        this.logoPadding = builder.logoPadding;
+        this.eyeShape = builder.eyeShape;
+        this.patternStyle = builder.patternStyle;
+    }
 
-    public QRStyles.EyeShape eyeShape = QRStyles.EyeShape.Squared;
-    public QRStyles.PatternStyle patternStyle = QRStyles.PatternStyle.Squared;
+    public int getWidth() { return width; }
+    public int getHeight() { return height; }
+    public int getQuietZone() { return quietZone; }
+    public Bitmap getLogo() { return logo; }
+    public Bitmap getBackground() { return background; }
+    public int getBackgroundColor() { return backgroundColor; }
+    public int getForegroundColor() { return foregroundColor; }
+    public QRErrorCorrectionLevel getErrorCorrectionLevel() { return errorCorrectionLevel; }
+    public float getDotSizeFactor() { return dotSizeFactor; }
+    public boolean isClearLogoBackground() { return clearLogoBackground; }
+    public int getLogoPadding() { return logoPadding; }
+    public QRStyles.EyeShape getEyeShape() { return eyeShape; }
+    public QRStyles.PatternStyle getPatternStyle() { return patternStyle; }
+
+    public static class Builder {
+        private int width = 500;
+        private int height = 500;
+        private int quietZone = 1;
+        private Bitmap logo = null;
+        private Bitmap background = null;
+        private int backgroundColor = Color.WHITE;
+        private int foregroundColor = Color.BLACK;
+        private QRErrorCorrectionLevel errorCorrectionLevel = QRErrorCorrectionLevel.H;
+        private float dotSizeFactor = 0.8f;
+        private boolean clearLogoBackground = true;
+        private int logoPadding = 0;
+        private QRStyles.EyeShape eyeShape = QRStyles.EyeShape.Squared;
+        private QRStyles.PatternStyle patternStyle = QRStyles.PatternStyle.Squared;
+
+        public Builder() {}
+
+        public Builder(QRCodeOptions base) {
+            this.width = base.width;
+            this.height = base.height;
+            this.quietZone = base.quietZone;
+            this.logo = base.logo;
+            this.background = base.background;
+            this.backgroundColor = base.backgroundColor;
+            this.foregroundColor = base.foregroundColor;
+            this.errorCorrectionLevel = base.errorCorrectionLevel;
+            this.dotSizeFactor = base.dotSizeFactor;
+            this.clearLogoBackground = base.clearLogoBackground;
+            this.logoPadding = base.logoPadding;
+            this.eyeShape = base.eyeShape;
+            this.patternStyle = base.patternStyle;
+        }
+
+        public Builder setWidth(int width) { this.width = width; return this; }
+        public Builder setHeight(int height) { this.height = height; return this; }
+        public Builder setQuietZone(int quietZone) { this.quietZone = quietZone; return this; }
+        public Builder setLogo(Bitmap logo) { this.logo = logo; return this; }
+        public Builder setBackground(Bitmap background) { this.background = background; return this; }
+        public Builder setBackgroundColor(int backgroundColor) { this.backgroundColor = backgroundColor; return this; }
+        public Builder setForegroundColor(int foregroundColor) { this.foregroundColor = foregroundColor; return this; }
+        public Builder setErrorCorrectionLevel(QRErrorCorrectionLevel level) { this.errorCorrectionLevel = level; return this; }
+        public Builder setDotSizeFactor(float dotSizeFactor) { this.dotSizeFactor = dotSizeFactor; return this; }
+        public Builder setClearLogoBackground(boolean clearLogoBackground) { this.clearLogoBackground = clearLogoBackground; return this; }
+        public Builder setLogoPadding(int logoPadding) { this.logoPadding = logoPadding; return this; }
+        public Builder setEyeShape(QRStyles.EyeShape eyeShape) { this.eyeShape = eyeShape; return this; }
+        public Builder setPatternStyle(QRStyles.PatternStyle patternStyle) { this.patternStyle = patternStyle; return this; }
+        public QRCodeOptions build() { return new QRCodeOptions(this); }
+    }
 }

--- a/QRSmith/src/main/java/com/akansh/qrsmith/renderer/QRRenderer.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/renderer/QRRenderer.java
@@ -27,48 +27,48 @@ public class QRRenderer {
         hints.put(EncodeHintType.CHARACTER_SET, "UTF-8");
         QRCode qrCode = Encoder.encode(content, errorCorrectionLevel, hints);
 
-        Bitmap bitmap = Bitmap.createBitmap(qrOptions.width, qrOptions.height, Bitmap.Config.ARGB_8888);
+        Bitmap bitmap = Bitmap.createBitmap(qrOptions.getWidth(), qrOptions.getHeight(), Bitmap.Config.ARGB_8888);
         Canvas canvas = new Canvas(bitmap);
 
-        if (qrOptions.background != null) {
-            Bitmap backgroundBitmap = Bitmap.createScaledBitmap(qrOptions.background, qrOptions.width, qrOptions.height, true);
+        if (qrOptions.getBackground() != null) {
+            Bitmap backgroundBitmap = Bitmap.createScaledBitmap(qrOptions.getBackground(), qrOptions.getWidth(), qrOptions.getHeight(), true);
             canvas.drawBitmap(backgroundBitmap, 0, 0, null);
         } else {
             Paint bgPaint = new Paint();
             bgPaint.setStyle(Paint.Style.FILL);
-            bgPaint.setColor(qrOptions.backgroundColor);
-            canvas.drawRect(0, 0, qrOptions.width, qrOptions.height, bgPaint);
+            bgPaint.setColor(qrOptions.getBackgroundColor());
+            canvas.drawRect(0, 0, qrOptions.getWidth(), qrOptions.getHeight(), bgPaint);
         }
 
         Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
         paint.setStyle(Paint.Style.FILL);
-        paint.setColor(qrOptions.foregroundColor);
+        paint.setColor(qrOptions.getForegroundColor());
 
         ByteMatrix input = qrCode.getMatrix();
         if (input == null) throw new IllegalStateException();
 
         int inputWidth = input.getWidth();
         int inputHeight = input.getHeight();
-        int qrWidth = inputWidth + qrOptions.quietZone * 2;
-        int qrHeight = inputHeight + qrOptions.quietZone * 2;
-        int outputWidth = Math.max(qrOptions.width, qrWidth);
-        int outputHeight = Math.max(qrOptions.height, qrHeight);
+        int qrWidth = inputWidth + qrOptions.getQuietZone() * 2;
+        int qrHeight = inputHeight + qrOptions.getQuietZone() * 2;
+        int outputWidth = Math.max(qrOptions.getWidth(), qrWidth);
+        int outputHeight = Math.max(qrOptions.getHeight(), qrHeight);
 
         int multiple = Math.min(outputWidth / qrWidth, outputHeight / qrHeight);
         int leftPadding = (outputWidth - (inputWidth * multiple)) / 2;
         int topPadding = (outputHeight - (inputHeight * multiple)) / 2;
         int FINDER_PATTERN_SIZE = 7;
 
-        Bitmap logo = qrOptions.logo;
-        int logoWidth = qrOptions.width / 5;
-        int logoHeight = qrOptions.height / 5;
-        int logoX = (qrOptions.width - logoWidth) / 2;
-        int logoY = (qrOptions.height - logoHeight) / 2;
+        Bitmap logo = qrOptions.getLogo();
+        int logoWidth = qrOptions.getWidth() / 5;
+        int logoHeight = qrOptions.getHeight() / 5;
+        int logoX = (qrOptions.getWidth() - logoWidth) / 2;
+        int logoY = (qrOptions.getHeight() - logoHeight) / 2;
 
-        if (logo != null && qrOptions.clearLogoBackground && qrOptions.background == null) {
+        if (logo != null && qrOptions.isClearLogoBackground() && qrOptions.getBackground() == null) {
             Paint clearPaint = new Paint();
             clearPaint.setStyle(Paint.Style.FILL);
-            clearPaint.setColor(qrOptions.backgroundColor);
+            clearPaint.setColor(qrOptions.getBackgroundColor());
             canvas.drawRect(logoX, logoY, logoX + logoWidth, logoY + logoHeight, clearPaint);
         }
 
@@ -85,14 +85,14 @@ public class QRRenderer {
                             outputX >= logoX && outputX < (logoX + logoWidth) - multiple &&
                             outputY >= logoY && outputY < (logoY + logoHeight) - multiple;
 
-                    if (!isInFinderPattern && (!isInLogoArea || !qrOptions.clearLogoBackground)) {
-                        if(qrOptions.patternStyle == QRStyles.PatternStyle.Squared) {
+                    if (!isInFinderPattern && (!isInLogoArea || !qrOptions.isClearLogoBackground())) {
+                        if(qrOptions.getPatternStyle() == QRStyles.PatternStyle.Squared) {
                             qrDataPatternRenderer.drawNormalStyle(canvas, paint, outputX, outputY, multiple);
-                        }else if(qrOptions.patternStyle == QRStyles.PatternStyle.Fluid) {
+                        }else if(qrOptions.getPatternStyle() == QRStyles.PatternStyle.Fluid) {
                             qrDataPatternRenderer.drawFluidStyle(canvas, paint, inputX, inputY, input, inputWidth, inputHeight, outputX, outputY, multiple);
-                        }else if(qrOptions.patternStyle == QRStyles.PatternStyle.Dotted) {
+                        }else if(qrOptions.getPatternStyle() == QRStyles.PatternStyle.Dotted) {
                             qrDataPatternRenderer.drawDottedStyle(canvas, paint, outputX, outputY, multiple);
-                        }else if(qrOptions.patternStyle == QRStyles.PatternStyle.Hexagonal) {
+                        }else if(qrOptions.getPatternStyle() == QRStyles.PatternStyle.Hexagonal) {
                             qrDataPatternRenderer.drawHexStyle(canvas, paint, outputX, outputY, multiple);
                         }
                     }
@@ -102,22 +102,22 @@ public class QRRenderer {
 
         int patternSize = multiple * FINDER_PATTERN_SIZE;
 
-        if(qrOptions.eyeShape == QRStyles.EyeShape.Squared) {
-            qrFinderPatternRenderer.drawSquaredStyle(canvas, paint, leftPadding, topPadding, patternSize, multiple, qrOptions.foregroundColor);
-            qrFinderPatternRenderer.drawSquaredStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, multiple, qrOptions.foregroundColor);
-            qrFinderPatternRenderer.drawSquaredStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, multiple, qrOptions.foregroundColor);
-        }else if(qrOptions.eyeShape == QRStyles.EyeShape.RoundSquared) {
-            qrFinderPatternRenderer.drawRoundedStyle(canvas, paint, leftPadding, topPadding, patternSize, multiple, qrOptions.foregroundColor);
-            qrFinderPatternRenderer.drawRoundedStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, multiple, qrOptions.foregroundColor);
-            qrFinderPatternRenderer.drawRoundedStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, multiple, qrOptions.foregroundColor);
-        }else if(qrOptions.eyeShape == QRStyles.EyeShape.Hexagonal) {
-            qrFinderPatternRenderer.drawHexStyle(canvas, paint, leftPadding, topPadding, patternSize, qrOptions.foregroundColor);
-            qrFinderPatternRenderer.drawHexStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, qrOptions.foregroundColor);
-            qrFinderPatternRenderer.drawHexStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, qrOptions.foregroundColor);
-        }else if(qrOptions.eyeShape == QRStyles.EyeShape.Rounded) {
-            qrFinderPatternRenderer.drawCircleStyle(canvas, paint, leftPadding, topPadding, patternSize, qrOptions.foregroundColor);
-            qrFinderPatternRenderer.drawCircleStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, qrOptions.foregroundColor);
-            qrFinderPatternRenderer.drawCircleStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, qrOptions.foregroundColor);
+        if(qrOptions.getEyeShape() == QRStyles.EyeShape.Squared) {
+            qrFinderPatternRenderer.drawSquaredStyle(canvas, paint, leftPadding, topPadding, patternSize, multiple, qrOptions.getForegroundColor());
+            qrFinderPatternRenderer.drawSquaredStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, multiple, qrOptions.getForegroundColor());
+            qrFinderPatternRenderer.drawSquaredStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, multiple, qrOptions.getForegroundColor());
+        }else if(qrOptions.getEyeShape() == QRStyles.EyeShape.RoundSquared) {
+            qrFinderPatternRenderer.drawRoundedStyle(canvas, paint, leftPadding, topPadding, patternSize, multiple, qrOptions.getForegroundColor());
+            qrFinderPatternRenderer.drawRoundedStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, multiple, qrOptions.getForegroundColor());
+            qrFinderPatternRenderer.drawRoundedStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, multiple, qrOptions.getForegroundColor());
+        }else if(qrOptions.getEyeShape() == QRStyles.EyeShape.Hexagonal) {
+            qrFinderPatternRenderer.drawHexStyle(canvas, paint, leftPadding, topPadding, patternSize, qrOptions.getForegroundColor());
+            qrFinderPatternRenderer.drawHexStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, qrOptions.getForegroundColor());
+            qrFinderPatternRenderer.drawHexStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, qrOptions.getForegroundColor());
+        }else if(qrOptions.getEyeShape() == QRStyles.EyeShape.Rounded) {
+            qrFinderPatternRenderer.drawCircleStyle(canvas, paint, leftPadding, topPadding, patternSize, qrOptions.getForegroundColor());
+            qrFinderPatternRenderer.drawCircleStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, qrOptions.getForegroundColor());
+            qrFinderPatternRenderer.drawCircleStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, qrOptions.getForegroundColor());
         }
 
 

--- a/README.md
+++ b/README.md
@@ -58,20 +58,24 @@ dependencies {
 ```java
 import com.akansh.qrsmith.QRSmith;
 import com.akansh.qrsmith.model.QRCodeOptions;
+import com.akansh.qrsmith.model.QRStyles;
 import android.graphics.Bitmap;
+import android.graphics.Color;
 
 // Define the QR code content
 String content = "https://example.com";
 
 // Create QR code options
-QRCodeOptions options = new QRCodeOptions();
-options.width = 500;
-options.height = 500;
-options.foregroundColor = Color.BLACK;
-options.backgroundColor = Color.WHITE;
-options.style = QRSmith.QRCodeStyle.SQUARED;
-options.radius = 5; // Rounded corners
-options.quietZone = 1; // Set quiet zone size
+QRCodeOptions options = new QRCodeOptions.Builder()
+        .setWidth(500)
+        .setHeight(500)
+        .setForegroundColor(Color.BLACK)
+        .setBackgroundColor(Color.WHITE)
+        .setPatternStyle(QRStyles.PatternStyle.Squared)
+        .setEyeShape(QRStyles.EyeShape.Squared)
+        .setDotSizeFactor(0.8f)
+        .setQuietZone(1)
+        .build();
 
 try {
     // Generate the QR code
@@ -87,7 +91,10 @@ try {
 ```java
 import com.akansh.qrsmith.QRSmith;
 import com.akansh.qrsmith.model.QRCodeOptions;
+import com.akansh.qrsmith.model.QRStyles;
+import com.akansh.qrsmith.model.QRErrorCorrectionLevel;
 import android.graphics.Bitmap;
+import android.graphics.Color;
 
 // Define the QR code content
 String content = "https://example.com";
@@ -97,18 +104,18 @@ Bitmap logo = BitmapFactory.decodeResource(getResources(), R.drawable.logo);
 Bitmap background = BitmapFactory.decodeResource(getResources(), R.drawable.background);
 
 // Create QR code options
-QRCodeOptions options = new QRCodeOptions();
-options.width = 600;
-options.height = 600;
-options.foregroundColor = Color.BLACK;
-options.backgroundColor = Color.WHITE;
-options.style = QRSmith.QRCodeStyle.HEXAGONAL;
-options.radius = 0; // Radius only affects SQUARED style
-options.logo = logo;
-options.background = background; // Set custom background
-options.dotSizeFactor = 0.8f;
-options.errorCorrectionLevel = QRSmith.QRErrorCorrectionLevel.Q;
-options.quietZone = 2; // Set quiet zone size
+QRCodeOptions options = new QRCodeOptions.Builder()
+        .setWidth(600)
+        .setHeight(600)
+        .setForegroundColor(Color.BLACK)
+        .setBackgroundColor(Color.WHITE)
+        .setPatternStyle(QRStyles.PatternStyle.Hexagonal)
+        .setLogo(logo)
+        .setBackground(background) // Set custom background
+        .setDotSizeFactor(0.8f)
+        .setErrorCorrectionLevel(QRErrorCorrectionLevel.Q)
+        .setQuietZone(2)
+        .build();
 
 try {
     // Generate the QR code

--- a/app/src/main/java/com/akansh/qrsmith/MainActivity.java
+++ b/app/src/main/java/com/akansh/qrsmith/MainActivity.java
@@ -36,19 +36,20 @@ public class MainActivity extends AppCompatActivity {
 
 //        Bitmap logo = BitmapFactory.decodeResource(getResources(), R.drawable.ic_android);
 //        Bitmap bg = BitmapFactory.decodeResource(getResources(), R.drawable.bg_img);
-        QRCodeOptions options = new QRCodeOptions();
-        options.width = 720;
-        options.height = 720;
-        options.backgroundColor = Color.WHITE;
-        options.foregroundColor = Color.BLACK;
-        options.errorCorrectionLevel = QRErrorCorrectionLevel.H;
-//        options.logo = logo;
-//        options.background = bg;
-        options.clearLogoBackground = true;
-        options.quietZone = 1;
-        options.dotSizeFactor = 1f;
-        options.patternStyle = QRStyles.PatternStyle.Dotted;
-        options.eyeShape = QRStyles.EyeShape.Hexagonal;
+        QRCodeOptions options = new QRCodeOptions.Builder()
+                .setWidth(720)
+                .setHeight(720)
+                .setBackgroundColor(Color.WHITE)
+                .setForegroundColor(Color.BLACK)
+                .setErrorCorrectionLevel(QRErrorCorrectionLevel.H)
+//                .setLogo(logo)
+//                .setBackground(bg)
+                .setClearLogoBackground(true)
+                .setQuietZone(1)
+                .setDotSizeFactor(1f)
+                .setPatternStyle(QRStyles.PatternStyle.Dotted)
+                .setEyeShape(QRStyles.EyeShape.Hexagonal)
+                .build();
 
         Bitmap bitmap = QRSmith.generateQRCode("Hello, World!", options);
         RoundedBitmapDrawable dr = RoundedBitmapDrawableFactory.create(getResources(), bitmap);


### PR DESCRIPTION
## Summary
- add builder pattern and getters for `QRCodeOptions`
- update renderer and generator to use new getters
- pad logo using a cloned builder when needed
- update sample usage in `MainActivity`
- refresh README examples for the builder API

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68566a389afc8332b7934ea41f2c549f