### PR TITLE
refactor: use all-caps enum constants for QRStyles

### DIFF
--- a/QRSmith/src/main/java/com/akansh/qrsmith/model/QRCodeOptions.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/model/QRCodeOptions.java
@@ -59,9 +59,9 @@ public class QRCodeOptions {
         private QRErrorCorrectionLevel errorCorrectionLevel = QRErrorCorrectionLevel.H;
         private boolean clearLogoBackground = true;
         private int logoPadding = 0;
-        private QRStyles.EyeFrameShape eyeFrameShape = QRStyles.EyeFrameShape.Square;
-        private QRStyles.EyeBallShape eyeBallShape = QRStyles.EyeBallShape.Square;
-        private QRStyles.PatternStyle patternStyle = QRStyles.PatternStyle.Square;
+        private QRStyles.EyeFrameShape eyeFrameShape = QRStyles.EyeFrameShape.SQUARE;
+        private QRStyles.EyeBallShape eyeBallShape = QRStyles.EyeBallShape.SQUARE;
+        private QRStyles.PatternStyle patternStyle = QRStyles.PatternStyle.SQUARE;
 
         public Builder() {}
 

--- a/QRSmith/src/main/java/com/akansh/qrsmith/model/QRStyles.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/model/QRStyles.java
@@ -2,19 +2,19 @@ package com.akansh.qrsmith.model;
 
 public class QRStyles {
     public enum EyeFrameShape {
-        Square, RoundSquare, Circle, Hexagon,
-        OneSharpCorner, TechEye, SoftRounded,
-        PinchedSquircle, BlobCorner, CornerWarp
+        SQUARE, ROUND_SQUARE, CIRCLE, HEXAGON,
+        ONE_SHARP_CORNER, TECH_EYE, SOFT_ROUNDED,
+        PINCHED_SQUIRCLE, BLOB_CORNER, CORNER_WARP
     }
 
     public enum EyeBallShape {
-        Square, RoundSquare, Circle, Hexagon,
-        OneSharpCorner, TechEye, SoftRounded,
-        PinchedSquircle, BlobCorner, CornerWarp,
-        PillStackH, PillStackV, Incurve, Chisel
+        SQUARE, ROUND_SQUARE, CIRCLE, HEXAGON,
+        ONE_SHARP_CORNER, TECH_EYE, SOFT_ROUNDED,
+        PINCHED_SQUIRCLE, BLOB_CORNER, CORNER_WARP,
+        PILL_STACK_H, PILL_STACK_V, INCURVE, CHISEL
     }
 
     public enum PatternStyle {
-        Square, Fluid, Dotted, Hexagon
+        SQUARE, FLUID, DOTTED, HEXAGON
     }
 }

--- a/QRSmith/src/main/java/com/akansh/qrsmith/renderer/QRRenderer.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/renderer/QRRenderer.java
@@ -87,13 +87,13 @@ public class QRRenderer {
                             outputY >= logoY && outputY < (logoY + logoHeight) - multiple;
 
                     if (!isInFinderPattern && (!isInLogoArea || !qrOptions.isClearLogoBackground())) {
-                        if(qrOptions.getPatternStyle() == QRStyles.PatternStyle.Square) {
+                        if(qrOptions.getPatternStyle() == QRStyles.PatternStyle.SQUARE) {
                             qrDataPatternRenderer.drawNormalStyle(canvas, paint, outputX, outputY, multiple);
-                        }else if(qrOptions.getPatternStyle() == QRStyles.PatternStyle.Fluid) {
+                        }else if(qrOptions.getPatternStyle() == QRStyles.PatternStyle.FLUID) {
                             qrDataPatternRenderer.drawFluidStyle(canvas, paint, inputX, inputY, input, inputWidth, inputHeight, outputX, outputY, multiple);
-                        }else if(qrOptions.getPatternStyle() == QRStyles.PatternStyle.Dotted) {
+                        }else if(qrOptions.getPatternStyle() == QRStyles.PatternStyle.DOTTED) {
                             qrDataPatternRenderer.drawDottedStyle(canvas, paint, outputX, outputY, multiple);
-                        }else if(qrOptions.getPatternStyle() == QRStyles.PatternStyle.Hexagon) {
+                        }else if(qrOptions.getPatternStyle() == QRStyles.PatternStyle.HEXAGON) {
                             qrDataPatternRenderer.drawHexStyle(canvas, paint, outputX, outputY, multiple);
                         }
                     }
@@ -104,102 +104,102 @@ public class QRRenderer {
         int patternSize = multiple * FINDER_PATTERN_SIZE;
 
         // Finder frame renderer
-        if(qrOptions.getEyeFrameShape() == QRStyles.EyeFrameShape.Square) {
+        if(qrOptions.getEyeFrameShape() == QRStyles.EyeFrameShape.SQUARE) {
             qrFinderFrameRenderer.drawSquaredStyle(canvas, paint, leftPadding, topPadding, patternSize, qrOptions.getForegroundColor());
             qrFinderFrameRenderer.drawSquaredStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, qrOptions.getForegroundColor());
             qrFinderFrameRenderer.drawSquaredStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, qrOptions.getForegroundColor());
-        }else if(qrOptions.getEyeFrameShape() == QRStyles.EyeFrameShape.RoundSquare) {
+        }else if(qrOptions.getEyeFrameShape() == QRStyles.EyeFrameShape.ROUND_SQUARE) {
             qrFinderFrameRenderer.drawRoundedSquaredStyle(canvas, paint, leftPadding, topPadding, patternSize, multiple, qrOptions.getForegroundColor());
             qrFinderFrameRenderer.drawRoundedSquaredStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, multiple, qrOptions.getForegroundColor());
             qrFinderFrameRenderer.drawRoundedSquaredStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, multiple, qrOptions.getForegroundColor());
-        }else if(qrOptions.getEyeFrameShape() == QRStyles.EyeFrameShape.Hexagon) {
+        }else if(qrOptions.getEyeFrameShape() == QRStyles.EyeFrameShape.HEXAGON) {
             qrFinderFrameRenderer.drawHexStyle(canvas, paint, leftPadding, topPadding, patternSize, qrOptions.getForegroundColor());
             qrFinderFrameRenderer.drawHexStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, qrOptions.getForegroundColor());
             qrFinderFrameRenderer.drawHexStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, qrOptions.getForegroundColor());
-        }else if(qrOptions.getEyeFrameShape() == QRStyles.EyeFrameShape.Circle) {
+        }else if(qrOptions.getEyeFrameShape() == QRStyles.EyeFrameShape.CIRCLE) {
             qrFinderFrameRenderer.drawCircleStyle(canvas, paint, leftPadding, topPadding, patternSize, qrOptions.getForegroundColor());
             qrFinderFrameRenderer.drawCircleStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, qrOptions.getForegroundColor());
             qrFinderFrameRenderer.drawCircleStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, qrOptions.getForegroundColor());
-        }else if(qrOptions.getEyeFrameShape() == QRStyles.EyeFrameShape.OneSharpCorner) {
+        }else if(qrOptions.getEyeFrameShape() == QRStyles.EyeFrameShape.ONE_SHARP_CORNER) {
             qrFinderFrameRenderer.drawOneSharpCornerStyle(canvas, paint, leftPadding, topPadding, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.TOP_LEFT);
             qrFinderFrameRenderer.drawOneSharpCornerStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.TOP_RIGHT);
             qrFinderFrameRenderer.drawOneSharpCornerStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.BOTTOM_LEFT);
-        }else if(qrOptions.getEyeFrameShape() == QRStyles.EyeFrameShape.TechEye) {
+        }else if(qrOptions.getEyeFrameShape() == QRStyles.EyeFrameShape.TECH_EYE) {
             qrFinderFrameRenderer.drawTechEyeStyle(canvas, paint, leftPadding, topPadding, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.TOP_LEFT);
             qrFinderFrameRenderer.drawTechEyeStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, multiple, qrOptions.getForegroundColor(),CommonShapeUtils.CornerPosition.TOP_RIGHT);
             qrFinderFrameRenderer.drawTechEyeStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.BOTTOM_LEFT);
-        }else if(qrOptions.getEyeFrameShape() == QRStyles.EyeFrameShape.SoftRounded) {
+        }else if(qrOptions.getEyeFrameShape() == QRStyles.EyeFrameShape.SOFT_ROUNDED) {
             qrFinderFrameRenderer.drawSoftRoundedStyle(canvas, paint, leftPadding, topPadding, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.TOP_LEFT);
             qrFinderFrameRenderer.drawSoftRoundedStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, multiple, qrOptions.getForegroundColor(),CommonShapeUtils.CornerPosition.TOP_RIGHT);
             qrFinderFrameRenderer.drawSoftRoundedStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.BOTTOM_LEFT);
-        }else if(qrOptions.getEyeFrameShape() == QRStyles.EyeFrameShape.PinchedSquircle) {
+        }else if(qrOptions.getEyeFrameShape() == QRStyles.EyeFrameShape.PINCHED_SQUIRCLE) {
             qrFinderFrameRenderer.drawPinchedSquircleStyle(canvas, paint, leftPadding, topPadding, patternSize,  qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.TOP_LEFT);
             qrFinderFrameRenderer.drawPinchedSquircleStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, qrOptions.getForegroundColor(),CommonShapeUtils.CornerPosition.TOP_RIGHT);
             qrFinderFrameRenderer.drawPinchedSquircleStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.BOTTOM_LEFT);
-        }else if(qrOptions.getEyeFrameShape() == QRStyles.EyeFrameShape.BlobCorner) {
+        }else if(qrOptions.getEyeFrameShape() == QRStyles.EyeFrameShape.BLOB_CORNER) {
             qrFinderFrameRenderer.drawBlobCornerStyle(canvas, paint, leftPadding, topPadding, patternSize,  qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.TOP_LEFT);
             qrFinderFrameRenderer.drawBlobCornerStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, qrOptions.getForegroundColor(),CommonShapeUtils.CornerPosition.TOP_RIGHT);
             qrFinderFrameRenderer.drawBlobCornerStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.BOTTOM_LEFT);
-        }else if(qrOptions.getEyeFrameShape() == QRStyles.EyeFrameShape.CornerWarp) {
+        }else if(qrOptions.getEyeFrameShape() == QRStyles.EyeFrameShape.CORNER_WARP) {
             qrFinderFrameRenderer.drawCornerWarpStyle(canvas, paint, leftPadding, topPadding, patternSize,  qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.TOP_LEFT);
             qrFinderFrameRenderer.drawCornerWarpStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, qrOptions.getForegroundColor(),CommonShapeUtils.CornerPosition.TOP_RIGHT);
             qrFinderFrameRenderer.drawCornerWarpStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.BOTTOM_LEFT);
         }
 
         // Finder ball renderer
-        if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.Square) {
+        if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.SQUARE) {
             qrFinderBallRenderer.drawSquaredStyle(canvas, paint, leftPadding, topPadding, patternSize, qrOptions.getForegroundColor());
             qrFinderBallRenderer.drawSquaredStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, qrOptions.getForegroundColor());
             qrFinderBallRenderer.drawSquaredStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, qrOptions.getForegroundColor());
-        }else if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.RoundSquare) {
+        }else if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.ROUND_SQUARE) {
             qrFinderBallRenderer.drawRoundedSquaredStyle(canvas, paint, leftPadding, topPadding, patternSize, multiple, qrOptions.getForegroundColor());
             qrFinderBallRenderer.drawRoundedSquaredStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, multiple, qrOptions.getForegroundColor());
             qrFinderBallRenderer.drawRoundedSquaredStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, multiple, qrOptions.getForegroundColor());
-        }else if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.Hexagon) {
+        }else if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.HEXAGON) {
             qrFinderBallRenderer.drawHexStyle(canvas, paint, leftPadding, topPadding, patternSize, qrOptions.getForegroundColor());
             qrFinderBallRenderer.drawHexStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, qrOptions.getForegroundColor());
             qrFinderBallRenderer.drawHexStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, qrOptions.getForegroundColor());
-        }else if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.Circle) {
+        }else if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.CIRCLE) {
             qrFinderBallRenderer.drawCircleStyle(canvas, paint, leftPadding, topPadding, patternSize, multiple, qrOptions.getForegroundColor());
             qrFinderBallRenderer.drawCircleStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, multiple, qrOptions.getForegroundColor());
             qrFinderBallRenderer.drawCircleStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, multiple, qrOptions.getForegroundColor());
-        }else if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.OneSharpCorner) {
+        }else if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.ONE_SHARP_CORNER) {
             qrFinderBallRenderer.drawOneSharpCornerStyle(canvas, paint, leftPadding, topPadding, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.TOP_LEFT);
             qrFinderBallRenderer.drawOneSharpCornerStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.TOP_RIGHT);
             qrFinderBallRenderer.drawOneSharpCornerStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.BOTTOM_LEFT);
-        }else if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.TechEye) {
+        }else if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.TECH_EYE) {
             qrFinderBallRenderer.drawTechEyeStyle(canvas, paint, leftPadding, topPadding, patternSize, multiple, qrOptions.getForegroundColor(),  CommonShapeUtils.CornerPosition.TOP_LEFT);
             qrFinderBallRenderer.drawTechEyeStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.TOP_RIGHT);
             qrFinderBallRenderer.drawTechEyeStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.BOTTOM_LEFT);
-        }else if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.SoftRounded) {
+        }else if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.SOFT_ROUNDED) {
             qrFinderBallRenderer.drawSoftRoundedStyle(canvas, paint, leftPadding, topPadding, patternSize, multiple, qrOptions.getForegroundColor(),  CommonShapeUtils.CornerPosition.TOP_LEFT);
             qrFinderBallRenderer.drawSoftRoundedStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.TOP_RIGHT);
             qrFinderBallRenderer.drawSoftRoundedStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.BOTTOM_LEFT);
-        }else if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.PinchedSquircle) {
+        }else if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.PINCHED_SQUIRCLE) {
             qrFinderBallRenderer.drawPinchedSquircleStyle(canvas, paint, leftPadding, topPadding, patternSize, multiple, qrOptions.getForegroundColor(),  CommonShapeUtils.CornerPosition.TOP_LEFT);
             qrFinderBallRenderer.drawPinchedSquircleStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.TOP_RIGHT);
             qrFinderBallRenderer.drawPinchedSquircleStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.BOTTOM_LEFT);
-        }else if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.BlobCorner) {
+        }else if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.BLOB_CORNER) {
             qrFinderBallRenderer.drawBlobCornerStyle(canvas, paint, leftPadding, topPadding, patternSize, multiple, qrOptions.getForegroundColor(),  CommonShapeUtils.CornerPosition.TOP_LEFT);
             qrFinderBallRenderer.drawBlobCornerStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.TOP_RIGHT);
             qrFinderBallRenderer.drawBlobCornerStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.BOTTOM_LEFT);
-        }else if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.CornerWarp) {
+        }else if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.CORNER_WARP) {
             qrFinderBallRenderer.drawCornerWarpStyle(canvas, paint, leftPadding, topPadding, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.TOP_LEFT);
             qrFinderBallRenderer.drawCornerWarpStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.TOP_RIGHT);
             qrFinderBallRenderer.drawCornerWarpStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.BOTTOM_LEFT);
-        }else if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.PillStackH) {
+        }else if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.PILL_STACK_H) {
             qrFinderBallRenderer.drawPillStackHStyle(canvas, paint, leftPadding, topPadding, patternSize, multiple, qrOptions.getForegroundColor(),  CommonShapeUtils.CornerPosition.TOP_LEFT);
             qrFinderBallRenderer.drawPillStackHStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.TOP_RIGHT);
             qrFinderBallRenderer.drawPillStackHStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.BOTTOM_LEFT);
-        }else if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.PillStackV) {
+        }else if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.PILL_STACK_V) {
             qrFinderBallRenderer.drawPillStackVStyle(canvas, paint, leftPadding, topPadding, patternSize, multiple, qrOptions.getForegroundColor(),  CommonShapeUtils.CornerPosition.TOP_LEFT);
             qrFinderBallRenderer.drawPillStackVStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.TOP_RIGHT);
             qrFinderBallRenderer.drawPillStackVStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.BOTTOM_LEFT);
-        }else if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.Incurve) {
+        }else if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.INCURVE) {
             qrFinderBallRenderer.drawIncurveStyle(canvas, paint, leftPadding, topPadding, patternSize, multiple, qrOptions.getForegroundColor(),  CommonShapeUtils.CornerPosition.TOP_LEFT);
             qrFinderBallRenderer.drawIncurveStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.TOP_RIGHT);
             qrFinderBallRenderer.drawIncurveStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.BOTTOM_LEFT);
-        }else if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.Chisel) {
+        }else if(qrOptions.getEyeBallShape() == QRStyles.EyeBallShape.CHISEL) {
             qrFinderBallRenderer.drawChiselStyle(canvas, paint, leftPadding, topPadding, patternSize, multiple, qrOptions.getForegroundColor(),  CommonShapeUtils.CornerPosition.TOP_LEFT);
             qrFinderBallRenderer.drawChiselStyle(canvas, paint, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.TOP_RIGHT);
             qrFinderBallRenderer.drawChiselStyle(canvas, paint, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple, patternSize, multiple, qrOptions.getForegroundColor(), CommonShapeUtils.CornerPosition.BOTTOM_LEFT);

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ QRSmith is a powerful and versatile Android library for generating advanced, cus
 - **Logo Integration**: Add logos with optional padding and background clearing.
 - **Custom Backgrounds**: Use custom images or colors as QR code backgrounds.
 - **Full Customization**: Adjust size, colors, quiet zones, and more.
-- **Customizable Finder Patterns**: Choose separate shapes for the finder frame and ball, including options like `Square`, `RoundSquare`, `Circle`, `Hexagon`, `OneSharpCorner`, `TechEye`, `SoftRounded`, `PinchedSquircle`, `BlobCorner`, and `CornerWarp`.
+- **Customizable Finder Patterns**: Choose separate shapes for the finder frame and ball, including options like `SQUARE`, `ROUND_SQUARE`, `CIRCLE`, `HEXAGON`, `ONE_SHARP_CORNER`, `TECH_EYE`, `SOFT_ROUNDED`, `PINCHED_SQUIRCLE`, `BLOB_CORNER`, and `CORNER_WARP`.
 - **Error Correction**: Supports error correction levels (L, M, Q, H) for data reliability.
 - **Developer-Friendly API**: Easy-to-use interface with robust customization options.
 
@@ -72,9 +72,9 @@ QRCodeOptions options = new QRCodeOptions.Builder()
         .setHeight(500)
         .setForegroundColor(Color.BLACK)
         .setBackgroundColor(Color.WHITE)
-        .setPatternStyle(QRStyles.PatternStyle.Square)
-        .setEyeFrameShape(QRStyles.EyeFrameShape.Square)
-        .setEyeBallShape(QRStyles.EyeBallShape.Square)
+        .setPatternStyle(QRStyles.PatternStyle.SQUARE)
+        .setEyeFrameShape(QRStyles.EyeFrameShape.SQUARE)
+        .setEyeBallShape(QRStyles.EyeBallShape.SQUARE)
         .setQuietZone(1)
         .build();
 
@@ -110,9 +110,9 @@ QRCodeOptions options = new QRCodeOptions.Builder()
         .setHeight(600)
         .setForegroundColor(Color.BLACK)
         .setBackgroundColor(Color.WHITE)
-        .setPatternStyle(QRStyles.PatternStyle.Hexagon)
-        .setEyeFrameShape(QRStyles.EyeFrameShape.Hexagon)
-        .setEyeBallShape(QRStyles.EyeBallShape.Hexagon)
+        .setPatternStyle(QRStyles.PatternStyle.HEXAGON)
+        .setEyeFrameShape(QRStyles.EyeFrameShape.HEXAGON)
+        .setEyeBallShape(QRStyles.EyeBallShape.HEXAGON)
         .setLogo(logo)
         .setBackground(background) // Set custom background
         .setErrorCorrectionLevel(QRErrorCorrectionLevel.Q)
@@ -138,10 +138,10 @@ QRSmith offers extensive customization through the `QRCodeOptions` class:
 | `height`               | Height of the QR code in pixels                   | 500           |
 | `foregroundColor`      | Color of the QR code foreground                   | `Color.BLACK` |
 | `backgroundColor`      | Color of the QR code background                   | `Color.WHITE` |
-| `patternStyle` | Pattern style (`Square`, `Fluid`, `Dotted`, `Hexagon`) | `Square`     |
+| `patternStyle` | Pattern style (`SQUARE`, `FLUID`, `DOTTED`, `HEXAGON`) | `SQUARE`     |
 | `logo`                 | Bitmap for the logo to overlay on the QR code     | `null`        |
-| `eyeFrameShape`      | Shape of the finder frame (`Square`, `RoundSquare`, `Circle`, `Hexagon`, `OneSharpCorner`, `TechEye`, `SoftRounded`, `PinchedSquircle`, `BlobCorner`, `CornerWarp`) | `Square`     |
-| `eyeBallShape`       | Shape of the finder ball (`Square`, `RoundSquare`, `Circle`, `Hexagon`, `OneSharpCorner`, `TechEye`, `SoftRounded`, `PinchedSquircle`, `BlobCorner`, `CornerWarp`) | `Square`     |
+| `eyeFrameShape`      | Shape of the finder frame (`SQUARE`, `ROUND_SQUARE`, `CIRCLE`, `HEXAGON`, `ONE_SHARP_CORNER`, `TECH_EYE`, `SOFT_ROUNDED`, `PINCHED_SQUIRCLE`, `BLOB_CORNER`, `CORNER_WARP`) | `SQUARE`     |
+| `eyeBallShape`       | Shape of the finder ball (`SQUARE`, `ROUND_SQUARE`, `CIRCLE`, `HEXAGON`, `ONE_SHARP_CORNER`, `TECH_EYE`, `SOFT_ROUNDED`, `PINCHED_SQUIRCLE`, `BLOB_CORNER`, `CORNER_WARP`) | `SQUARE`     |
 | `errorCorrectionLevel` | Error correction level (`L`, `M`, `Q`, `H`)       | `H`           |
 | `clearLogoBackground`  | Clears the background under the logo              | `true`        |
 | `background`           | Bitmap for the QR code background                 | `null`        |

--- a/app/src/main/java/com/akansh/qrsmith/MainActivity.java
+++ b/app/src/main/java/com/akansh/qrsmith/MainActivity.java
@@ -47,9 +47,9 @@ public class MainActivity extends AppCompatActivity {
                 .setClearLogoBackground(true)
                 .setQuietZone(1)
                 .setLogoPadding(2)
-                .setPatternStyle(QRStyles.PatternStyle.Hexagon)
-                .setEyeBallShape(QRStyles.EyeBallShape.PillStackH)
-                .setEyeFrameShape(QRStyles.EyeFrameShape.CornerWarp)
+                .setPatternStyle(QRStyles.PatternStyle.HEXAGON)
+                .setEyeBallShape(QRStyles.EyeBallShape.PILL_STACK_H)
+                .setEyeFrameShape(QRStyles.EyeFrameShape.CORNER_WARP)
                 .build();
 
         Bitmap bitmap = QRSmith.generateQRCode("Hello, World!", options);


### PR DESCRIPTION
## Summary
- normalize enum constants in `QRStyles`
- update renderer and options classes to use new enum names
- adjust default values in `QRCodeOptions`
- update sample app and README documentation

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68599c6089c48332a114899617583fb4