### PR TITLE
Add gradient rendering options

### DIFF
--- a/QRSmith/src/main/java/com/akansh/qrsmith/model/QRCodeOptions.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/model/QRCodeOptions.java
@@ -3,6 +3,10 @@ package com.akansh.qrsmith.model;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 
+/**
+ * Configuration options for generating a QR code.
+ */
+
 public class QRCodeOptions {
     private final int width;
     private final int height;
@@ -17,6 +21,18 @@ public class QRCodeOptions {
     private final QRStyles.EyeFrameShape eyeFrameShape;
     private final QRStyles.EyeBallShape eyeBallShape;
     private final QRStyles.PatternStyle patternStyle;
+    private final int[] foregroundGradientColors;
+    private final int[] backgroundGradientColors;
+    private final GradientOrientation foregroundGradientOrientation;
+    private final GradientOrientation backgroundGradientOrientation;
+
+    /** Orientation for linear gradients. */
+    public enum GradientOrientation {
+        LEFT_RIGHT,
+        TOP_BOTTOM,
+        TL_BR,
+        BL_TR
+    }
 
     private QRCodeOptions(Builder builder) {
         this.width = builder.width;
@@ -32,6 +48,10 @@ public class QRCodeOptions {
         this.eyeFrameShape = builder.eyeFrameShape;
         this.eyeBallShape = builder.eyeBallShape;
         this.patternStyle = builder.patternStyle;
+        this.foregroundGradientColors = builder.foregroundGradientColors;
+        this.backgroundGradientColors = builder.backgroundGradientColors;
+        this.foregroundGradientOrientation = builder.foregroundGradientOrientation;
+        this.backgroundGradientOrientation = builder.backgroundGradientOrientation;
     }
 
     public int getWidth() { return width; }
@@ -47,6 +67,10 @@ public class QRCodeOptions {
     public QRStyles.EyeFrameShape getEyeFrameShape() { return eyeFrameShape; }
     public QRStyles.EyeBallShape getEyeBallShape() { return eyeBallShape; }
     public QRStyles.PatternStyle getPatternStyle() { return patternStyle; }
+    public int[] getForegroundGradientColors() { return foregroundGradientColors; }
+    public int[] getBackgroundGradientColors() { return backgroundGradientColors; }
+    public GradientOrientation getForegroundGradientOrientation() { return foregroundGradientOrientation; }
+    public GradientOrientation getBackgroundGradientOrientation() { return backgroundGradientOrientation; }
 
     public static class Builder {
         private int width = 500;
@@ -62,6 +86,10 @@ public class QRCodeOptions {
         private QRStyles.EyeFrameShape eyeFrameShape = QRStyles.EyeFrameShape.SQUARE;
         private QRStyles.EyeBallShape eyeBallShape = QRStyles.EyeBallShape.SQUARE;
         private QRStyles.PatternStyle patternStyle = QRStyles.PatternStyle.SQUARE;
+        private int[] foregroundGradientColors = null;
+        private int[] backgroundGradientColors = null;
+        private GradientOrientation foregroundGradientOrientation = GradientOrientation.LEFT_RIGHT;
+        private GradientOrientation backgroundGradientOrientation = GradientOrientation.LEFT_RIGHT;
 
         public Builder() {}
 
@@ -79,6 +107,10 @@ public class QRCodeOptions {
             this.eyeFrameShape = base.eyeFrameShape;
             this.eyeBallShape = base.eyeBallShape;
             this.patternStyle = base.patternStyle;
+            this.foregroundGradientColors = base.foregroundGradientColors;
+            this.backgroundGradientColors = base.backgroundGradientColors;
+            this.foregroundGradientOrientation = base.foregroundGradientOrientation;
+            this.backgroundGradientOrientation = base.backgroundGradientOrientation;
         }
 
         public Builder setWidth(int width) { this.width = width; return this; }
@@ -94,6 +126,17 @@ public class QRCodeOptions {
         public Builder setEyeFrameShape(QRStyles.EyeFrameShape eyeFrameShape) { this.eyeFrameShape = eyeFrameShape; return this; }
         public Builder setEyeBallShape(QRStyles.EyeBallShape eyeBallShape) { this.eyeBallShape = eyeBallShape; return this; }
         public Builder setPatternStyle(QRStyles.PatternStyle patternStyle) { this.patternStyle = patternStyle; return this; }
+        public Builder setForegroundGradient(int[] colors, GradientOrientation orientation) {
+            this.foregroundGradientColors = colors;
+            this.foregroundGradientOrientation = orientation;
+            return this;
+        }
+
+        public Builder setBackgroundGradient(int[] colors, GradientOrientation orientation) {
+            this.backgroundGradientColors = colors;
+            this.backgroundGradientOrientation = orientation;
+            return this;
+        }
         public QRCodeOptions build() { return new QRCodeOptions(this); }
     }
 }

--- a/QRSmith/src/main/java/com/akansh/qrsmith/renderer/CommonShapeUtils.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/renderer/CommonShapeUtils.java
@@ -26,14 +26,14 @@ class CommonShapeUtils {
 
         Path ball = CommonShapeUtils.makeFinderFramePath(pos, innerSizePx, x + innerOffPx, y + innerOffPx, svgCode, orientation, rotation);
 
-        paint.setColor(color);
+        if (paint.getShader() == null) paint.setColor(color);
         paint.setStyle(Paint.Style.FILL);
         paint.setAntiAlias(true);
         canvas.drawPath(ball, paint);
     }
 
     public static void drawCommonSVGStyleEyeFrame(Canvas canvas, Paint paint, int x, int y, int size, int color, CommonShapeUtils.CornerPosition pos, int[] orientation, String svgCode) {
-        paint.setColor(color);
+        if (paint.getShader() == null) paint.setColor(color);
         paint.setStyle(Paint.Style.FILL);
         paint.setAntiAlias(true);
 
@@ -93,7 +93,7 @@ class CommonShapeUtils {
         float innerOffset = multiple * gapModules;
         float innerSize = size - (innerOffset * 2f);
 
-        paint.setColor(color);
+        if (paint.getShader() == null) paint.setColor(color);
         paint.setAntiAlias(true);
         paint.setStyle(Paint.Style.FILL);    // filled, not stroked
 

--- a/QRSmith/src/main/java/com/akansh/qrsmith/renderer/QRFinderBallRenderer.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/renderer/QRFinderBallRenderer.java
@@ -12,7 +12,7 @@ public class QRFinderBallRenderer {
     public void drawRoundedSquaredStyle(Canvas canvas, Paint paint, int x, int y, int size, int multiple, int color) {
         float radius = (multiple / 2f) * 2f; // Tweak as needed
 
-        paint.setColor(color);
+        if (paint.getShader() == null) paint.setColor(color);
         paint.setAntiAlias(true);
         paint.setStyle(Paint.Style.FILL);    // filled, not stroked
 
@@ -31,7 +31,7 @@ public class QRFinderBallRenderer {
         int innerSize = size * 3 / 7;
         int innerOffset = size * 2 / 7;
 
-        paint.setColor(color);
+        if (paint.getShader() == null) paint.setColor(color);
         paint.setAntiAlias(true);
         paint.setStrokeWidth(stroke);
         paint.setStyle(Paint.Style.FILL);
@@ -42,7 +42,7 @@ public class QRFinderBallRenderer {
         float centerX = x + size/2f;
         float centerY = y + size/2f;
 
-        paint.setColor(color);
+        if (paint.getShader() == null) paint.setColor(color);
         paint.setStyle(Paint.Style.FILL);
         CommonShapeUtils.drawHexagon(canvas, paint, centerX, centerY, size/4.0f);
     }
@@ -53,7 +53,7 @@ public class QRFinderBallRenderer {
         float MIDDLE_DOT_OFFSET = multiple * gapModules;
         float MIDDLE_DOT_DIAMETER = circleDiameter - (MIDDLE_DOT_OFFSET * 2f);
 
-        paint.setColor(foregroundColor);
+        if (paint.getShader() == null) paint.setColor(foregroundColor);
         paint.setStyle(Paint.Style.FILL);
         canvas.drawOval(new RectF((x + MIDDLE_DOT_OFFSET), (y + MIDDLE_DOT_OFFSET), (x + MIDDLE_DOT_OFFSET + MIDDLE_DOT_DIAMETER), (y + MIDDLE_DOT_OFFSET + MIDDLE_DOT_DIAMETER)), paint);
     }
@@ -62,7 +62,7 @@ public class QRFinderBallRenderer {
 
         float radius = (multiple / 2f) * 2f; // Tweak as needed
 
-        paint.setColor(color);
+        if (paint.getShader() == null) paint.setColor(color);
         paint.setAntiAlias(true);
         paint.setStyle(Paint.Style.FILL);    // filled, not stroked
 
@@ -90,7 +90,7 @@ public class QRFinderBallRenderer {
     public void drawTechEyeStyle(Canvas canvas, Paint paint, int x, int y, int size, int multiple, int color, CommonShapeUtils.CornerPosition sharpCorner) {
         float radius = (multiple / 2f) * 2f; // Tweak as needed
 
-        paint.setColor(color);
+        if (paint.getShader() == null) paint.setColor(color);
         paint.setAntiAlias(true);
         paint.setStyle(Paint.Style.FILL);    // filled, not stroked
 
@@ -121,7 +121,7 @@ public class QRFinderBallRenderer {
     public void drawSoftRoundedStyle(Canvas canvas, Paint paint, int x, int y, int size, int multiple, int color, CommonShapeUtils.CornerPosition sharpCorner) {
         float radius = (multiple / 2f) * 2f; // Tweak as needed
 
-        paint.setColor(color);
+        if (paint.getShader() == null) paint.setColor(color);
         paint.setAntiAlias(true);
         paint.setStyle(Paint.Style.FILL);    // filled, not stroked
 

--- a/QRSmith/src/main/java/com/akansh/qrsmith/renderer/QRFinderFrameRenderer.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/renderer/QRFinderFrameRenderer.java
@@ -11,7 +11,7 @@ class QRFinderFrameRenderer {
         // stroke and radius follow the library’s own math
         int stroke = size / 7;
 
-        paint.setColor(color);
+        if (paint.getShader() == null) paint.setColor(color);
         paint.setAntiAlias(true);
         paint.setStyle(Paint.Style.STROKE);
         paint.setStrokeWidth(stroke);
@@ -38,7 +38,7 @@ class QRFinderFrameRenderer {
     public void drawSquaredStyle(Canvas canvas, Paint paint, int x, int y, int size, int color) {
         int stroke = size / 7;
 
-        paint.setColor(color);
+        if (paint.getShader() == null) paint.setColor(color);
         paint.setAntiAlias(true);
         paint.setStyle(Paint.Style.STROKE);
         paint.setStrokeWidth(stroke);
@@ -50,7 +50,7 @@ class QRFinderFrameRenderer {
         float centerY = y + size/2f;
 
         // Draw outer hexagon
-        paint.setColor(color);
+        if (paint.getShader() == null) paint.setColor(color);
         paint.setAntiAlias(true);
         paint.setStyle(Paint.Style.STROKE);
         paint.setStrokeWidth(size/8f);
@@ -61,7 +61,7 @@ class QRFinderFrameRenderer {
         int WHITE_CIRCLE_OFFSET = circleDiameter / 7;
 
         // Draw the outer circle
-        paint.setColor(foregroundColor);
+        if (paint.getShader() == null) paint.setColor(foregroundColor);
         paint.setAntiAlias(true);
         paint.setStyle(Paint.Style.STROKE);
         paint.setStrokeWidth(WHITE_CIRCLE_OFFSET);

--- a/QRSmith/src/main/java/com/akansh/qrsmith/renderer/QRRenderer.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/renderer/QRRenderer.java
@@ -3,6 +3,8 @@ package com.akansh.qrsmith.renderer;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Paint;
+import android.graphics.LinearGradient;
+import android.graphics.Shader;
 
 import com.google.zxing.EncodeHintType;
 import com.google.zxing.WriterException;
@@ -36,13 +38,29 @@ public class QRRenderer {
         } else {
             Paint bgPaint = new Paint();
             bgPaint.setStyle(Paint.Style.FILL);
-            bgPaint.setColor(qrOptions.getBackgroundColor());
+            if (qrOptions.getBackgroundGradientColors() != null) {
+                bgPaint.setShader(buildGradient(
+                        qrOptions.getBackgroundGradientColors(),
+                        qrOptions.getBackgroundGradientOrientation(),
+                        qrOptions.getWidth(),
+                        qrOptions.getHeight()));
+            } else {
+                bgPaint.setColor(qrOptions.getBackgroundColor());
+            }
             canvas.drawRect(0, 0, qrOptions.getWidth(), qrOptions.getHeight(), bgPaint);
         }
 
         Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
         paint.setStyle(Paint.Style.FILL);
-        paint.setColor(qrOptions.getForegroundColor());
+        if (qrOptions.getForegroundGradientColors() != null) {
+            paint.setShader(buildGradient(
+                    qrOptions.getForegroundGradientColors(),
+                    qrOptions.getForegroundGradientOrientation(),
+                    qrOptions.getWidth(),
+                    qrOptions.getHeight()));
+        } else {
+            paint.setColor(qrOptions.getForegroundColor());
+        }
 
         ByteMatrix input = qrCode.getMatrix();
         if (input == null) throw new IllegalStateException();
@@ -256,5 +274,24 @@ public class QRRenderer {
                 break;
 
         }
+    }
+
+    private LinearGradient buildGradient(int[] colors, QRCodeOptions.GradientOrientation orientation, int width, int height) {
+        float startX = 0, startY = 0, endX = width, endY = height;
+        switch (orientation) {
+            case TOP_BOTTOM:
+                endX = 0;
+                break;
+            case LEFT_RIGHT:
+                endY = 0;
+                break;
+            case TL_BR:
+                break; // defaults already set
+            case BL_TR:
+                startY = height;
+                endY = 0;
+                break;
+        }
+        return new LinearGradient(startX, startY, endX, endY, colors, null, Shader.TileMode.CLAMP);
     }
 }

--- a/README.md
+++ b/README.md
@@ -128,6 +128,17 @@ try {
 }
 ```
 
+### Gradient Example
+```java
+int[] fgColors = new int[]{Color.RED, Color.BLUE};
+int[] bgColors = new int[]{Color.WHITE, Color.LTGRAY};
+QRCodeOptions options = new QRCodeOptions.Builder()
+        .setForegroundGradient(fgColors, QRCodeOptions.GradientOrientation.TOP_BOTTOM)
+        .setBackgroundGradient(bgColors, QRCodeOptions.GradientOrientation.TOP_BOTTOM)
+        .build();
+Bitmap qrCode = QRSmith.generateQRCode("https://example.com", options);
+```
+
 ## Customization Options
 
 QRSmith offers extensive customization through the `QRCodeOptions` class:
@@ -138,6 +149,10 @@ QRSmith offers extensive customization through the `QRCodeOptions` class:
 | `height`               | Height of the QR code in pixels                   | 500           |
 | `foregroundColor`      | Color of the QR code foreground                   | `Color.BLACK` |
 | `backgroundColor`      | Color of the QR code background                   | `Color.WHITE` |
+| `foregroundGradientColors` | Colors for a gradient QR foreground | `null` |
+| `backgroundGradientColors` | Colors for the background gradient | `null` |
+| `foregroundGradientOrientation` | Gradient orientation (`LEFT_RIGHT`, `TOP_BOTTOM`, `TL_BR`, `BL_TR`) | `LEFT_RIGHT` |
+| `backgroundGradientOrientation` | Orientation for the background gradient | `LEFT_RIGHT` |
 | `patternStyle` | Pattern style (`SQUARE`, `FLUID`, `DOTTED`, `HEXAGON`) | `SQUARE`     |
 | `logo`                 | Bitmap for the logo to overlay on the QR code     | `null`        |
 | `eyeFrameShape`      | Shape of the finder frame (`SQUARE`, `ROUND_SQUARE`, `CIRCLE`, `HEXAGON`, `ONE_SHARP_CORNER`, `TECH_EYE`, `SOFT_ROUNDED`, `PINCHED_SQUIRCLE`, `BLOB_CORNER`, `CORNER_WARP`) | `SQUARE`     |


### PR DESCRIPTION
## Summary
- add gradient configuration fields to `QRCodeOptions`
- support gradient shaders in `QRRenderer`
- keep gradient shader active in shape renderers
- document gradient options and usage example in README

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685a9a22fb808332ab1f0ef625cf236a