### PR TITLE
Add eye color customization for QR code eyes

### DIFF
--- a/QRSmith/src/main/java/com/akansh/qrsmith/model/QRCodeOptions.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/model/QRCodeOptions.java
@@ -20,8 +20,8 @@ public class QRCodeOptions {
     private final int logoPadding;
     private final QRStyles.EyeFrameShape eyeFrameShape;
     private final QRStyles.EyeBallShape eyeBallShape;
-    private final Integer eyeFrameColor;
-    private final Integer eyeBallColor;
+    private final int eyeFrameColor;
+    private final int eyeBallColor;
     private final QRStyles.PatternStyle patternStyle;
     private final int[] foregroundGradientColors;
     private final int[] backgroundGradientColors;

--- a/QRSmith/src/main/java/com/akansh/qrsmith/model/QRCodeOptions.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/model/QRCodeOptions.java
@@ -20,6 +20,8 @@ public class QRCodeOptions {
     private final int logoPadding;
     private final QRStyles.EyeFrameShape eyeFrameShape;
     private final QRStyles.EyeBallShape eyeBallShape;
+    private final Integer eyeFrameColor;
+    private final Integer eyeBallColor;
     private final QRStyles.PatternStyle patternStyle;
     private final int[] foregroundGradientColors;
     private final int[] backgroundGradientColors;
@@ -47,6 +49,8 @@ public class QRCodeOptions {
         this.logoPadding = builder.logoPadding;
         this.eyeFrameShape = builder.eyeFrameShape;
         this.eyeBallShape = builder.eyeBallShape;
+        this.eyeFrameColor = builder.eyeFrameColor;
+        this.eyeBallColor = builder.eyeBallColor;
         this.patternStyle = builder.patternStyle;
         this.foregroundGradientColors = builder.foregroundGradientColors;
         this.backgroundGradientColors = builder.backgroundGradientColors;
@@ -66,6 +70,8 @@ public class QRCodeOptions {
     public int getLogoPadding() { return logoPadding; }
     public QRStyles.EyeFrameShape getEyeFrameShape() { return eyeFrameShape; }
     public QRStyles.EyeBallShape getEyeBallShape() { return eyeBallShape; }
+    public Integer getEyeFrameColor() { return eyeFrameColor; }
+    public Integer getEyeBallColor() { return eyeBallColor; }
     public QRStyles.PatternStyle getPatternStyle() { return patternStyle; }
     public int[] getForegroundGradientColors() { return foregroundGradientColors; }
     public int[] getBackgroundGradientColors() { return backgroundGradientColors; }
@@ -90,6 +96,8 @@ public class QRCodeOptions {
         private int[] backgroundGradientColors = null;
         private GradientOrientation foregroundGradientOrientation = GradientOrientation.LEFT_RIGHT;
         private GradientOrientation backgroundGradientOrientation = GradientOrientation.LEFT_RIGHT;
+        private Integer eyeFrameColor = null;
+        private Integer eyeBallColor = null;
 
         public Builder() {}
 
@@ -106,6 +114,8 @@ public class QRCodeOptions {
             this.logoPadding = base.logoPadding;
             this.eyeFrameShape = base.eyeFrameShape;
             this.eyeBallShape = base.eyeBallShape;
+            this.eyeFrameColor = base.eyeFrameColor;
+            this.eyeBallColor = base.eyeBallColor;
             this.patternStyle = base.patternStyle;
             this.foregroundGradientColors = base.foregroundGradientColors;
             this.backgroundGradientColors = base.backgroundGradientColors;
@@ -125,6 +135,8 @@ public class QRCodeOptions {
         public Builder setLogoPadding(int logoPadding) { this.logoPadding = logoPadding; return this; }
         public Builder setEyeFrameShape(QRStyles.EyeFrameShape eyeFrameShape) { this.eyeFrameShape = eyeFrameShape; return this; }
         public Builder setEyeBallShape(QRStyles.EyeBallShape eyeBallShape) { this.eyeBallShape = eyeBallShape; return this; }
+        public Builder setEyeFrameColor(int color) { this.eyeFrameColor = color; return this; }
+        public Builder setEyeBallColor(int color) { this.eyeBallColor = color; return this; }
         public Builder setPatternStyle(QRStyles.PatternStyle patternStyle) { this.patternStyle = patternStyle; return this; }
         public Builder setForegroundGradient(int[] colors, GradientOrientation orientation) {
             this.foregroundGradientColors = colors;

--- a/QRSmith/src/main/java/com/akansh/qrsmith/renderer/QRRenderer.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/renderer/QRRenderer.java
@@ -123,11 +123,24 @@ public class QRRenderer {
             leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple
         };
 
+        // Prepare solid paints for eyes
+        Paint framePaint = new Paint(paint);
+        framePaint.setShader(null);
+        int frameColor = qrOptions.getEyeFrameColor() != null ?
+                qrOptions.getEyeFrameColor() : qrOptions.getForegroundColor();
+        framePaint.setColor(frameColor);
+
+        Paint ballPaint = new Paint(paint);
+        ballPaint.setShader(null);
+        int ballColor = qrOptions.getEyeBallColor() != null ?
+                qrOptions.getEyeBallColor() : qrOptions.getForegroundColor();
+        ballPaint.setColor(ballColor);
+
         // Finder frame renderer
-        drawEyeFrame(qrOptions.getEyeFrameShape(), canvas, paint, EyeAlignmentX, EyeAlignmentY, EyeAlignmentZ, patternSize, multiple, qrOptions.getForegroundColor());
+        drawEyeFrame(qrOptions.getEyeFrameShape(), canvas, framePaint, EyeAlignmentX, EyeAlignmentY, EyeAlignmentZ, patternSize, multiple, frameColor);
 
         // Finder ball renderer
-        drawEyeBall(qrOptions.getEyeBallShape(), canvas, paint, EyeAlignmentX, EyeAlignmentY, EyeAlignmentZ, patternSize, multiple, qrOptions.getForegroundColor());
+        drawEyeBall(qrOptions.getEyeBallShape(), canvas, ballPaint, EyeAlignmentX, EyeAlignmentY, EyeAlignmentZ, patternSize, multiple, ballColor);
 
         if (logo != null) {
             Bitmap scaledLogo = Bitmap.createScaledBitmap(logo, logoWidth, logoHeight, true);

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ QRCodeOptions options = new QRCodeOptions.Builder()
         .setPatternStyle(QRStyles.PatternStyle.HEXAGON)
         .setEyeFrameShape(QRStyles.EyeFrameShape.HEXAGON)
         .setEyeBallShape(QRStyles.EyeBallShape.HEXAGON)
+        .setEyeFrameColor(Color.BLUE)
+        .setEyeBallColor(Color.RED)
         .setLogo(logo)
         .setBackground(background) // Set custom background
         .setErrorCorrectionLevel(QRErrorCorrectionLevel.Q)
@@ -157,6 +159,8 @@ QRSmith offers extensive customization through the `QRCodeOptions` class:
 | `logo`                 | Bitmap for the logo to overlay on the QR code     | `null`        |
 | `eyeFrameShape`      | Shape of the finder frame (`SQUARE`, `ROUND_SQUARE`, `CIRCLE`, `HEXAGON`, `ONE_SHARP_CORNER`, `TECH_EYE`, `SOFT_ROUNDED`, `PINCHED_SQUIRCLE`, `BLOB_CORNER`, `CORNER_WARP`) | `SQUARE`     |
 | `eyeBallShape`       | Shape of the finder ball (`SQUARE`, `ROUND_SQUARE`, `CIRCLE`, `HEXAGON`, `ONE_SHARP_CORNER`, `TECH_EYE`, `SOFT_ROUNDED`, `PINCHED_SQUIRCLE`, `BLOB_CORNER`, `CORNER_WARP`) | `SQUARE`     |
+| `eyeFrameColor`      | Solid color for finder frames (overrides gradients) | `null` |
+| `eyeBallColor`       | Solid color for finder balls (overrides gradients)  | `null` |
 | `errorCorrectionLevel` | Error correction level (`L`, `M`, `Q`, `H`)       | `H`           |
 | `clearLogoBackground`  | Clears the background under the logo              | `true`        |
 | `background`           | Bitmap for the QR code background                 | `null`        |

--- a/app/src/main/java/com/akansh/qrsmith/MainActivity.java
+++ b/app/src/main/java/com/akansh/qrsmith/MainActivity.java
@@ -57,7 +57,7 @@ public class MainActivity extends AppCompatActivity {
                 .setEyeBallShape(QRStyles.EyeBallShape.CHISEL)
                 .setEyeFrameShape(QRStyles.EyeFrameShape.CIRCLE)
                 .setEyeFrameColor(Color.BLUE)
-                .setEyeBallColor(Color.RED)
+                .setEyeBallColor(Color.BLACK)
                 .build();
 
         Bitmap bitmap = QRSmith.generateQRCode("Hello, World!", options);

--- a/app/src/main/java/com/akansh/qrsmith/MainActivity.java
+++ b/app/src/main/java/com/akansh/qrsmith/MainActivity.java
@@ -56,6 +56,8 @@ public class MainActivity extends AppCompatActivity {
                 .setPatternStyle(QRStyles.PatternStyle.HEXAGON)
                 .setEyeBallShape(QRStyles.EyeBallShape.CHISEL)
                 .setEyeFrameShape(QRStyles.EyeFrameShape.CIRCLE)
+                .setEyeFrameColor(Color.BLUE)
+                .setEyeBallColor(Color.RED)
                 .build();
 
         Bitmap bitmap = QRSmith.generateQRCode("Hello, World!", options);


### PR DESCRIPTION
## Summary
- allow custom eye frame and eye ball colors via `QRCodeOptions`
- render eyes with solid colors independent of gradients
- document the new options and update sample code
- showcase new customization in demo `MainActivity`

## Testing
- `./gradlew build` *(fails: unable to download Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685af0413ebc8332853e923cbe05be74