### PR TITLE
Add radial gradient option

### DIFF
--- a/QRSmith/src/main/java/com/akansh/qrsmith/model/QRCodeOptions.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/model/QRCodeOptions.java
@@ -28,12 +28,16 @@ public class QRCodeOptions {
     private final GradientOrientation foregroundGradientOrientation;
     private final GradientOrientation backgroundGradientOrientation;
 
-    /** Orientation for linear gradients. */
+    /**
+     * Orientation for gradients. The first four values are used for
+     * linear gradients while {@code RADIAL} creates a radial gradient.
+     */
     public enum GradientOrientation {
         LEFT_RIGHT,
         TOP_BOTTOM,
         TL_BR,
-        BL_TR
+        BL_TR,
+        RADIAL
     }
 
     private QRCodeOptions(Builder builder) {

--- a/QRSmith/src/main/java/com/akansh/qrsmith/renderer/QRRenderer.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/renderer/QRRenderer.java
@@ -4,6 +4,7 @@ import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.LinearGradient;
+import android.graphics.RadialGradient;
 import android.graphics.Shader;
 
 import com.google.zxing.EncodeHintType;
@@ -313,7 +314,14 @@ public class QRRenderer {
         }
     }
 
-    private LinearGradient buildGradient(int[] colors, QRCodeOptions.GradientOrientation orientation, int width, int height) {
+    private Shader buildGradient(int[] colors, QRCodeOptions.GradientOrientation orientation, int width, int height) {
+        if (orientation == QRCodeOptions.GradientOrientation.RADIAL) {
+            float cx = width / 2f;
+            float cy = height / 2f;
+            float radius = Math.max(width, height) / 2f;
+            return new RadialGradient(cx, cy, radius, colors, null, Shader.TileMode.CLAMP);
+        }
+
         float startX = 0, startY = 0, endX = width, endY = height;
         switch (orientation) {
             case TOP_BOTTOM:
@@ -327,6 +335,8 @@ public class QRRenderer {
             case BL_TR:
                 startY = height;
                 endY = 0;
+                break;
+            default:
                 break;
         }
         return new LinearGradient(startX, startY, endX, endY, colors, null, Shader.TileMode.CLAMP);

--- a/QRSmith/src/test/java/com/akansh/qrsmith/GradientBuilderTest.java
+++ b/QRSmith/src/test/java/com/akansh/qrsmith/GradientBuilderTest.java
@@ -1,0 +1,25 @@
+package com.akansh.qrsmith;
+
+import android.graphics.Color;
+import android.graphics.Shader;
+import android.graphics.RadialGradient;
+
+import com.akansh.qrsmith.model.QRCodeOptions;
+import com.akansh.qrsmith.renderer.QRRenderer;
+
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertTrue;
+
+public class GradientBuilderTest {
+    @Test
+    public void radialOrientationProducesRadialGradient() throws Exception {
+        QRRenderer renderer = new QRRenderer();
+        Method m = QRRenderer.class.getDeclaredMethod("buildGradient", int[].class, QRCodeOptions.GradientOrientation.class, int.class, int.class);
+        m.setAccessible(true);
+        Shader shader = (Shader) m.invoke(renderer, new int[]{Color.RED, Color.BLUE}, QRCodeOptions.GradientOrientation.RADIAL, 100, 100);
+        assertTrue(shader instanceof RadialGradient);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ try {
 int[] fgColors = new int[]{Color.RED, Color.BLUE};
 int[] bgColors = new int[]{Color.WHITE, Color.LTGRAY};
 QRCodeOptions options = new QRCodeOptions.Builder()
-        .setForegroundGradient(fgColors, QRCodeOptions.GradientOrientation.TOP_BOTTOM)
-        .setBackgroundGradient(bgColors, QRCodeOptions.GradientOrientation.TOP_BOTTOM)
+        .setForegroundGradient(fgColors, QRCodeOptions.GradientOrientation.RADIAL)
+        .setBackgroundGradient(bgColors, QRCodeOptions.GradientOrientation.RADIAL)
         .build();
 Bitmap qrCode = QRSmith.generateQRCode("https://example.com", options);
 ```
@@ -153,8 +153,8 @@ QRSmith offers extensive customization through the `QRCodeOptions` class:
 | `backgroundColor`      | Color of the QR code background                   | `Color.WHITE` |
 | `foregroundGradientColors` | Colors for a gradient QR foreground | `null` |
 | `backgroundGradientColors` | Colors for the background gradient | `null` |
-| `foregroundGradientOrientation` | Gradient orientation (`LEFT_RIGHT`, `TOP_BOTTOM`, `TL_BR`, `BL_TR`) | `LEFT_RIGHT` |
-| `backgroundGradientOrientation` | Orientation for the background gradient | `LEFT_RIGHT` |
+| `foregroundGradientOrientation` | Gradient orientation (`LEFT_RIGHT`, `TOP_BOTTOM`, `TL_BR`, `BL_TR`, `RADIAL`) | `LEFT_RIGHT` |
+| `backgroundGradientOrientation` | Orientation for the background gradient (`LEFT_RIGHT`, `TOP_BOTTOM`, `TL_BR`, `BL_TR`, `RADIAL`) | `LEFT_RIGHT` |
 | `patternStyle` | Pattern style (`SQUARE`, `FLUID`, `S_DOT`, `L_DOT`, `HEXAGON`, `X_AXIS_FLUID`, `Y_AXIS_FLUID`, `DIAMOND`, `STAR`) | `SQUARE`     |
 | `logo`                 | Bitmap for the logo to overlay on the QR code     | `null`        |
 | `eyeFrameShape`      | Shape of the finder frame (`SQUARE`, `ROUND_SQUARE`, `CIRCLE`, `HEXAGON`, `ONE_SHARP_CORNER`, `TECH_EYE`, `SOFT_ROUNDED`, `PINCHED_SQUIRCLE`, `BLOB_CORNER`, `CORNER_WARP`) | `SQUARE`     |


### PR DESCRIPTION
## Summary
- add RADIAL gradient orientation support
- update gradient builder in `QRRenderer`
- document RADIAL option and usage in README
- test gradient builder produces a `RadialGradient`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to download Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685afc91d3088332984d5cc193beb88c