### PR TITLE
Fix eye gradient rendering

### DIFF
--- a/QRSmith/src/main/java/com/akansh/qrsmith/renderer/CommonShapeUtils.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/renderer/CommonShapeUtils.java
@@ -120,7 +120,9 @@ class CommonShapeUtils {
         // stroke and radius follow the library’s own math
         int stroke = size / 7;
 
-        paint.setColor(color);
+        if (paint.getShader() == null) {
+            paint.setColor(color);
+        }
         paint.setAntiAlias(true);
         paint.setStyle(Paint.Style.STROKE);
         paint.setStrokeWidth(stroke);

--- a/QRSmith/src/main/java/com/akansh/qrsmith/renderer/QRRenderer.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/renderer/QRRenderer.java
@@ -124,24 +124,33 @@ public class QRRenderer {
             leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple
         };
 
-        // Prepare solid paints for eyes
+        // Prepare paints for eyes.  Start with the base paint so any gradient
+        // specified for the foreground is preserved. Only override the color if
+        // a custom eye color was provided.
         Paint framePaint = new Paint(paint);
-        framePaint.setShader(null);
-        int frameColor = qrOptions.getEyeFrameColor() != null ?
-                qrOptions.getEyeFrameColor() : qrOptions.getForegroundColor();
-        framePaint.setColor(frameColor);
+        Integer frameColor = qrOptions.getEyeFrameColor();
+        if (frameColor != null) {
+            framePaint.setShader(null);
+            framePaint.setColor(frameColor);
+        }
 
         Paint ballPaint = new Paint(paint);
-        ballPaint.setShader(null);
-        int ballColor = qrOptions.getEyeBallColor() != null ?
-                qrOptions.getEyeBallColor() : qrOptions.getForegroundColor();
-        ballPaint.setColor(ballColor);
+        Integer ballColor = qrOptions.getEyeBallColor();
+        if (ballColor != null) {
+            ballPaint.setShader(null);
+            ballPaint.setColor(ballColor);
+        }
+
+        // Default color values for methods that require an explicit color even
+        // when a shader is used
+        int frameColorValue = frameColor != null ? frameColor : qrOptions.getForegroundColor();
+        int ballColorValue = ballColor != null ? ballColor : qrOptions.getForegroundColor();
 
         // Finder frame renderer
-        drawEyeFrame(qrOptions.getEyeFrameShape(), canvas, framePaint, EyeAlignmentX, EyeAlignmentY, EyeAlignmentZ, patternSize, multiple, frameColor);
+        drawEyeFrame(qrOptions.getEyeFrameShape(), canvas, framePaint, EyeAlignmentX, EyeAlignmentY, EyeAlignmentZ, patternSize, multiple, frameColorValue);
 
         // Finder ball renderer
-        drawEyeBall(qrOptions.getEyeBallShape(), canvas, ballPaint, EyeAlignmentX, EyeAlignmentY, EyeAlignmentZ, patternSize, multiple, ballColor);
+        drawEyeBall(qrOptions.getEyeBallShape(), canvas, ballPaint, EyeAlignmentX, EyeAlignmentY, EyeAlignmentZ, patternSize, multiple, ballColorValue);
 
         if (logo != null) {
             Bitmap scaledLogo = Bitmap.createScaledBitmap(logo, logoWidth, logoHeight, true);


### PR DESCRIPTION
## Summary
- preserve gradients in finder frames and balls when no eye color is specified
- respect shader when drawing multi-round-corner frames

## Testing
- `./gradlew test` *(fails: Unable to download gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_685b09919cb083329c497889c1c83db9