### PR TITLE
Tune ball padding

### DIFF
--- a/QRSmith/src/main/java/com/akansh/qrsmith/renderer/CommonShapeUtils.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/renderer/CommonShapeUtils.java
@@ -20,7 +20,7 @@ class CommonShapeUtils {
     }
 
     public static void drawCommonSVGStyleEyeBall(Canvas canvas, Paint paint, int x, int y, int size, int multiple, int color,int[] orientation, CommonShapeUtils.CornerPosition pos, Collection<String> svgCode, float rotation) {
-        float gapModules  = 1.8f;
+        float gapModules  = 2.0f;
         float innerOffPx  = multiple * gapModules;
         float innerSizePx = size - 2f * innerOffPx;
 
@@ -93,7 +93,7 @@ class CommonShapeUtils {
 
 
     public static void drawMultiRoundCornerStyleBall(Canvas canvas, Paint paint, int x, int y, int size, int multiple, int color, float[] radii) {
-        float gapModules = 1.8f;
+        float gapModules = 2.0f;
         float innerOffset = multiple * gapModules;
         float innerSize = size - (innerOffset * 2f);
 

--- a/QRSmith/src/main/java/com/akansh/qrsmith/renderer/QRFinderBallRenderer.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/renderer/QRFinderBallRenderer.java
@@ -53,7 +53,7 @@ public class QRFinderBallRenderer {
 
     public void drawCircleStyle(Canvas canvas, Paint paint, int x, int y, int circleDiameter, int multiple, int foregroundColor) {
 
-        float gapModules = 1.6f;
+        float gapModules = 2.0f;
         float MIDDLE_DOT_OFFSET = multiple * gapModules;
         float MIDDLE_DOT_DIAMETER = circleDiameter - (MIDDLE_DOT_OFFSET * 2f);
 


### PR DESCRIPTION
## Summary
- tune the gap used in eye ball rendering
- apply the same value to circular finder balls

## Testing
- `gradle build` *(fails: plugin dependencies not available offline)*

------
https://chatgpt.com/codex/tasks/task_e_6866cf0ddc488332bca7b211b7782800