### PR TITLE
Make logo padding transparent

### DIFF
--- a/QRSmith/src/main/java/com/akansh/qrsmith/QRSmith.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/QRSmith.java
@@ -71,8 +71,11 @@ public class QRSmith {
         int newWidth = originalBitmap.getWidth() + paddingPx * 2;
         int newHeight = originalBitmap.getHeight() + paddingPx * 2;
 
-        // Always use ARGB_8888 to preserve transparency in the padding area
+        // Always use ARGB_8888 so padding stays transparent
         Bitmap paddedBitmap = Bitmap.createBitmap(newWidth, newHeight, Bitmap.Config.ARGB_8888);
+
+        // Ensure the background starts fully transparent
+        paddedBitmap.eraseColor(android.graphics.Color.TRANSPARENT);
 
         // Important: match the density, in case you use the density for scaling
         paddedBitmap.setDensity(originalBitmap.getDensity());

--- a/QRSmith/src/main/java/com/akansh/qrsmith/QRSmith.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/QRSmith.java
@@ -71,14 +71,8 @@ public class QRSmith {
         int newWidth = originalBitmap.getWidth() + paddingPx * 2;
         int newHeight = originalBitmap.getHeight() + paddingPx * 2;
 
-        // Fallback to ARGB_8888 if the original config is null
-        Bitmap.Config bitmapConfig = originalBitmap.getConfig();
-        if (bitmapConfig == null) {
-            bitmapConfig = Bitmap.Config.ARGB_8888;
-        }
-
-        // Create a new bitmap
-        Bitmap paddedBitmap = Bitmap.createBitmap(newWidth, newHeight, bitmapConfig);
+        // Always use ARGB_8888 to preserve transparency in the padding area
+        Bitmap paddedBitmap = Bitmap.createBitmap(newWidth, newHeight, Bitmap.Config.ARGB_8888);
 
         // Important: match the density, in case you use the density for scaling
         paddedBitmap.setDensity(originalBitmap.getDensity());

--- a/QRSmith/src/main/java/com/akansh/qrsmith/renderer/QRRenderer.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/renderer/QRRenderer.java
@@ -87,8 +87,9 @@ public class QRRenderer {
         if (logo != null && qrOptions.isClearLogoBackground() && qrOptions.getBackground() == null) {
             Paint clearPaint = new Paint();
             clearPaint.setStyle(Paint.Style.FILL);
-            clearPaint.setColor(qrOptions.getBackgroundColor());
+            clearPaint.setXfermode(new android.graphics.PorterDuffXfermode(android.graphics.PorterDuff.Mode.CLEAR));
             canvas.drawRect(logoX, logoY, logoX + logoWidth, logoY + logoHeight, clearPaint);
+            clearPaint.setXfermode(null);
         }
 
         for (int inputY = 0; inputY < inputHeight; inputY++) {

--- a/QRSmith/src/main/java/com/akansh/qrsmith/renderer/QRRenderer.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/renderer/QRRenderer.java
@@ -84,7 +84,7 @@ public class QRRenderer {
         int logoX = (qrOptions.getWidth() - logoWidth) / 2;
         int logoY = (qrOptions.getHeight() - logoHeight) / 2;
 
-        if (logo != null && qrOptions.isClearLogoBackground() && qrOptions.getBackground() == null) {
+        if (logo != null && qrOptions.isClearLogoBackground()) {
             Paint clearPaint = new Paint();
             clearPaint.setStyle(Paint.Style.FILL);
             clearPaint.setXfermode(new android.graphics.PorterDuffXfermode(android.graphics.PorterDuff.Mode.CLEAR));


### PR DESCRIPTION
## Summary
- preserve transparency when padding logos by always using ARGB_8888 bitmaps
- clear the logo background using PorterDuff `CLEAR` mode to avoid white boxes

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6871f756cf188332b3bb8ddc6a2a43fb