### PR TITLE
Fix logo transparency and padding

### DIFF
--- a/QRSmith/src/main/java/com/akansh/qrsmith/QRSmith.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/QRSmith.java
@@ -65,20 +65,12 @@ public class QRSmith {
             return null;
         }
 
-        paddingPx = paddingPx * 100;
-
         // Calculate the size of the new bitmap
         int newWidth = originalBitmap.getWidth() + paddingPx * 2;
         int newHeight = originalBitmap.getHeight() + paddingPx * 2;
 
-        // Fallback to ARGB_8888 if the original config is null
-        Bitmap.Config bitmapConfig = originalBitmap.getConfig();
-        if (bitmapConfig == null) {
-            bitmapConfig = Bitmap.Config.ARGB_8888;
-        }
-
-        // Create a new bitmap
-        Bitmap paddedBitmap = Bitmap.createBitmap(newWidth, newHeight, bitmapConfig);
+        // Always create the padded bitmap with ARGB_8888 to preserve transparency
+        Bitmap paddedBitmap = Bitmap.createBitmap(newWidth, newHeight, Bitmap.Config.ARGB_8888);
 
         // Important: match the density, in case you use the density for scaling
         paddedBitmap.setDensity(originalBitmap.getDensity());

--- a/QRSmith/src/main/java/com/akansh/qrsmith/renderer/QRRenderer.java
+++ b/QRSmith/src/main/java/com/akansh/qrsmith/renderer/QRRenderer.java
@@ -84,12 +84,6 @@ public class QRRenderer {
         int logoX = (qrOptions.getWidth() - logoWidth) / 2;
         int logoY = (qrOptions.getHeight() - logoHeight) / 2;
 
-        if (logo != null && qrOptions.isClearLogoBackground() && qrOptions.getBackground() == null) {
-            Paint clearPaint = new Paint();
-            clearPaint.setStyle(Paint.Style.FILL);
-            clearPaint.setColor(qrOptions.getBackgroundColor());
-            canvas.drawRect(logoX, logoY, logoX + logoWidth, logoY + logoHeight, clearPaint);
-        }
 
         for (int inputY = 0; inputY < inputHeight; inputY++) {
             int outputY = topPadding + (multiple * inputY);


### PR DESCRIPTION
## Summary
- remove logo clearing rectangle from QR rendering
- create padded logos with `ARGB_8888` and keep padding size

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6871ff65fba0833296f2b353777b0fff